### PR TITLE
Ups the Vulture bullet range to 64.

### DIFF
--- a/code/datums/ammo/bullet/sniper.dm
+++ b/code/datums/ammo/bullet/sniper.dm
@@ -47,6 +47,7 @@
 
 /datum/ammo/bullet/sniper/anti_materiel
 	name = "anti-materiel sniper bullet"
+	max_range = 64 //doubled from 32, it's an AMR sniper bullet - Bam
 
 	shrapnel_chance = 0 // This isn't leaving any shrapnel.
 	accuracy = HIT_ACCURACY_TIER_8


### PR DESCRIPTION
# About the pull request
Ups the range of the Vulture to 64 tiles

# Explain why it's good for the game
It's an AMR. Bullet go boom.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->



Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


# Changelog

:cl: Bamhalazam
balance: rebalanced something
/:cl:

